### PR TITLE
Add information on IMDSv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Example AWS Metadata proxy to protect against attack vectors targetting AWS Credentials 
 
+## Preface
+AWS updated their metadata service in Nov '20 ([IMDSv2](https://aws.amazon.com/about-aws/whats-new/2019/11/announcing-updates-amazon-ec2-instance-metadata-service/)). With IMDSv2 a token will be sent when requesting the metadata service, therefore the risk of an attacker requesting the metadata service through ssrf has been minimized. There is a few blogposts about implementation details ([getting started with imdsv2](https://blog.appsecco.com/getting-started-with-version-2-of-aws-ec2-instance-metadata-service-imdsv2-2ad03a1f3650)). 
+
+Depending on your usecase and the threat model it could be reasonable to just use the IMDSV2. 
+
+
 ## Getting Started
 
 Clone the repo

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Example AWS Metadata proxy to protect against attack vectors targetting AWS Credentials 
 
 ## Preface
-AWS updated their metadata service in Nov '20 ([IMDSv2](https://aws.amazon.com/about-aws/whats-new/2019/11/announcing-updates-amazon-ec2-instance-metadata-service/)). With IMDSv2 a token will be sent when requesting the metadata service, therefore the risk of an attacker requesting the metadata service through ssrf has been minimized. There is a few blogposts about implementation details ([getting started with imdsv2](https://blog.appsecco.com/getting-started-with-version-2-of-aws-ec2-instance-metadata-service-imdsv2-2ad03a1f3650)). 
+AWS updated their metadata service in Nov '19 ([IMDSv2](https://aws.amazon.com/about-aws/whats-new/2019/11/announcing-updates-amazon-ec2-instance-metadata-service/)). With IMDSv2 a token will be sent when requesting the metadata service, therefore the risk of an attacker requesting the metadata service through ssrf has been minimized. There is a few blogposts about implementation details ([getting started with imdsv2](https://blog.appsecco.com/getting-started-with-version-2-of-aws-ec2-instance-metadata-service-imdsv2-2ad03a1f3650)). 
 
 Depending on your usecase and the threat model it could be reasonable to just use the IMDSV2. 
 

--- a/ThreatDragonModels/AWS Metadata Threat Model/AWS Metadata Threat Model.json
+++ b/ThreatDragonModels/AWS Metadata Threat Model/AWS Metadata Threat Model.json
@@ -1,0 +1,10 @@
+{
+  "summary": {
+    "title": "AWS Metadata Threat Model",
+    "owner": "Philip"
+  },
+  "detail": {
+    "contributors": [],
+    "diagrams": []
+  }
+}

--- a/ThreatDragonModels/AWS Metadata Threat Model/AWS Metadata Threat Model.json
+++ b/ThreatDragonModels/AWS Metadata Threat Model/AWS Metadata Threat Model.json
@@ -6,6 +6,12 @@
   },
   "detail": {
     "contributors": [],
-    "diagrams": []
+    "diagrams": [
+      {
+        "title": "asd",
+        "thumbnail": "./public/content/images/thumbnail.jpg",
+        "id": 0
+      }
+    ]
   }
 }

--- a/ThreatDragonModels/AWS Metadata Threat Model/AWS Metadata Threat Model.json
+++ b/ThreatDragonModels/AWS Metadata Threat Model/AWS Metadata Threat Model.json
@@ -1,7 +1,8 @@
 {
   "summary": {
     "title": "AWS Metadata Threat Model",
-    "owner": "Philip"
+    "owner": "Philip",
+    "description": "Test"
   },
   "detail": {
     "contributors": [],


### PR DESCRIPTION
Using the metadata proxy does not - depending on the threat model and the used imds version - necessarily make sense. 

Therefore i added information on imdsv2 in the preface.